### PR TITLE
Modify files for consistency

### DIFF
--- a/examples/rand_wave/rand_wave.ino
+++ b/examples/rand_wave/rand_wave.ino
@@ -3,7 +3,7 @@
   Date:    7/10/18
   Purpose: Use random number generator to wave arms.
 */
-#include <KHR_1.h>
+#include <Arduino_KHR1.h>
 
 void setup() {
   attach_KHR_1();//Setup pins

--- a/lib/Arduino_KHR1.cpp
+++ b/lib/Arduino_KHR1.cpp
@@ -1,5 +1,5 @@
 /* 
- * KHR_1.cpp - Library to control the 
+ * Arduino_KHR1.cpp - Library to control the 
  * Kondo KHR_1.
  *
  * Created by Aaron Chan, April 11, 2018
@@ -25,7 +25,7 @@
 */
 
 //#include "Arduino.h"//Redundant includes. "Arduino.h" is in "KHR_1.h"
-#include "KHR_1.h"
+#include "Arduino_KHR1.h"
 
 // KHR_1 servos
 VarSpeedServo left_s_pitch;

--- a/lib/Arduino_KHR1.h
+++ b/lib/Arduino_KHR1.h
@@ -1,5 +1,5 @@
 /* 
- * KHR_1.h - Library to control the 
+ * Arduino_KHR1.h - Library to control the 
  * Kondo KHR_1.
  *
  * Created by Aaron Chan, April 11, 2018

--- a/lib/Arduino_KHR1.h
+++ b/lib/Arduino_KHR1.h
@@ -3,6 +3,7 @@
  * Kondo KHR_1.
  *
  * Created by Aaron Chan, April 11, 2018
+ * Edited by William Brines, Oct 07, 2018 
  *
  * The KHR_1 servo channels have been renumbered for this Arduino
  * implementation. These numbers do not necessarily correspond 
@@ -33,25 +34,26 @@
 //S - Shoulder
 //H - Hip
 //A - Ankle
+#define R_S_PITCH 1
 #define L_S_PITCH 2
-#define R_S_PITCH 3
+#define R_S_ROLL  3
 #define L_S_ROLL  4
-#define R_S_ROLL  5
+#define R_ELBOW   5
 #define L_ELBOW   6
-#define R_ELBOW   7
+
 /*
-#define L_H_ROLL
-#define R_H_ROLL
-#define L_H_PITCH
-#define R_H_PITCH
-#define L_KNEE
-#define R_KNEE
-#define L_A_PITCH
-#define R_A_PITCH
-#define L_A_ROLL
-#define R_A_ROLL
+#define R_H_ROLL 7
+#define L_H_ROLL 8
+#define R_H_PITCH 9
+#define L_H_PITCH 10
+#define R_KNEE 11
+#define L_KNEE 12
+#define R_A_PITCH 13
+#define L_A_PITCH 14
+#define R_A_ROLL 15
+#define L_A_ROLL 16
 */
-#define HEAD      8
+#define HEAD 8 // 17 when the VarSpeedServo is fixed to have more servos.
 
 // setup functions
 void attach_KHR_1(void);

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,3 +1,3 @@
-## KHR-1 Library
+## Arduino_KHR1 Library
 Arduino control implementation for the KHR-1 using the VarSpeedServo library.
 Set Motions are hardcoded


### PR DESCRIPTION
This contains changes for file consistency.

Includes changes to resolve issues from #12 problems.

Changes include:

- Modified .h and .cpp files from "KHR_1" to "Arduino_KHR1" to match repo name.
- Changed #defines in Arduino_KHR1.h to match the servo diagrams.

Side Note: Due to current limitations in the VarSpeedServo.h lib the head was set to ch-8 and the lower limbs are still commented out.

Modified FIles:
KHR_1.h -> Arduino_KHR1.h
KHR_1.cpp -> Arduino_KHR1.cpp
rand_wave.ino