### PR TITLE
Fix servo channels diagram link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We will not be using the RCB-1 for this project. Servo Control will be done by A
 ## Servo Mapping
 The Servos are mapped for reference as seen below:
 
-![KHR-1_ServoChannels.png](https://github.com/pdx-robotics/Arduino_KHR-1/blob/feature/semaphore/KHR-1_ServoChannels.png)
+![KHR-1_ServoChannels.png](https://github.com/pdx-robotics/Arduino_KHR-1/blob/08d8fdf9f8c0942e947cd8a796170fd26b10ed48/KHR-1_ServoChannels.png)
 
 | Part | Left | Right|
 |----|:-----:|:----:|


### PR DESCRIPTION
Updated the diagram to the permalink for [KHR-1_ServoChannels.png](https://github.com/pdx-robotics/Arduino_KHR-1/blob/08d8fdf9f8c0942e947cd8a796170fd26b10ed48/KHR-1_ServoChannels.png). No more broken links.